### PR TITLE
Rotate opponent pieces on the board

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -131,8 +131,12 @@ export default class ShogiKifViewer extends Plugin {
           const cell = boardHost.createDiv({ cls: 'cell' });
           const P = board[r-1][f-1];
           if (P) {
-            cell.setText(P.kind);
-            if (P.side==='W') cell.style.opacity = '0.75';
+            const pieceEl = cell.createSpan({ cls: 'piece', text: P.kind });
+            if (P.side === 'W') {
+              pieceEl.addClass('piece-opponent');
+            } else {
+              pieceEl.addClass('piece-player');
+            }
           }
           if (lastTo && lastTo.f===f && lastTo.r===r) cell.addClass('highlight-to');
           if (lastFrom && lastFrom.f===f && lastFrom.r===r) cell.addClass('highlight-from');

--- a/styles.css
+++ b/styles.css
@@ -16,14 +16,22 @@ gap: 2px;
 user-select: none;
 }
 .shogi-kif .cell {
-width: 36px; height: 36px;
-display: flex; align-items: center; justify-content: center;
-background: var(--background-secondary);
-border-radius: 4px;
-font-weight: 600;
+  width: 36px; height: 36px;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--background-secondary);
+  border-radius: 4px;
+  font-weight: 600;
+}
+.shogi-kif .cell .piece {
+  display: inline-block;
+  font-weight: inherit;
+}
+.shogi-kif .cell .piece-opponent {
+  transform: rotate(180deg);
+  opacity: 0.75;
 }
 .shogi-kif .cell.highlight-to {
-outline: 2px solid #6aa84f;
+  outline: 2px solid #6aa84f;
 }
 .shogi-kif .cell.highlight-from {
 outline: 2px dashed #cc0000;


### PR DESCRIPTION
## Summary
- render shogi pieces using span elements so opponent pieces can be styled separately
- add CSS to rotate and dim opponent pieces so they appear upside down like on a real board

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea718ddf8832f817642260f15e97b