### PR TITLE
Add support for hands and drops in KIF viewer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,26 @@ display: flex;
 gap: 6px;
 margin-bottom: 8px;
 }
+.shogi-kif .hands {
+display: flex;
+justify-content: center;
+align-items: center;
+gap: 6px;
+margin: 4px 0;
+flex-wrap: wrap;
+font-size: 0.9em;
+}
+.shogi-kif .hands-label {
+font-weight: 600;
+}
+.shogi-kif .hand-piece {
+padding: 2px 6px;
+border-radius: 4px;
+background: var(--background-secondary);
+}
+.shogi-kif .hands-empty {
+opacity: 0.6;
+}
 .shogi-kif .board {
 display: grid;
 grid-template-columns: repeat(9, 36px);


### PR DESCRIPTION
## Summary
- track captured pieces as each side's hand and render them around the board
- extend KIF parsing and move application to support drops and capture handling for "同" squares
- style the new hand displays to integrate with the existing layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf284a2588832fa81878a3cf47ed37