### PR TITLE
Add variation selection for KIF viewer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,10 @@ display: flex;
 gap: 6px;
 margin-bottom: 8px;
 }
+.shogi-kif .toolbar .variation-select {
+  padding: 2px 6px;
+  max-width: 240px;
+}
 .shogi-kif .board {
 display: grid;
 grid-template-columns: repeat(9, 36px);


### PR DESCRIPTION
## Summary
- extend the KIF parser with variation-aware data structures and helpers
- add a variation dropdown that swaps the move list and keeps comments/timestamps in sync
- tweak toolbar styling so the new selector fits the layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf2a6a6d40832f90f97c53d190ff51