### PR TITLE
Add variation selection to KIF viewer

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,18 @@ interface Move {
   drop?: boolean;        // 持ち駒からの打ち
   comment?: string;      // * コメント
   timestamp?: string;    // ( 0:12/00:00:12) など
+  rawTo?: string;        // 元の移動先表示 (例: "同")
+}
+
+interface VariationLine {
+  startMoveNumber: number;
+  moves: ParsedMove[];
+  parent?: { line: VariationLine; anchorMoveCount: number };
+  leadVariations: VariationLine[];
+}
+
+interface ParsedMove extends Move {
+  variations: VariationLine[];
 }
 
 const JP_NUM_FULL = '１２３４５６７８９';
@@ -75,56 +87,122 @@ type Hands = Record<Side, PieceKind[]>;
 
 // Very small KIF move parser for lines like:
 // "   1 ２六歩(27)( 0:12/00:00:12)" or with comments lines starting with '*'
-function parseKif(text: string): { header: Record<string,string>, moves: Move[] } {
+function parseKif(text: string): { header: Record<string,string>, root: VariationLine } {
   const header: Record<string,string> = {};
-  const moves: Move[] = [];
+  const root: VariationLine = { startMoveNumber: 1, moves: [], leadVariations: [] };
+  interface ParseContext { line: VariationLine; prevMove?: ParsedMove; }
+  const rootContext: ParseContext = { line: root };
+  const contextStack: ParseContext[] = [rootContext];
+
   const lines = text.split(/\r?\n/);
   const piecePattern = '(成香|成桂|成銀|馬|龍|と|歩|香|桂|銀|金|角|飛|玉|王)';
   const moveRe = new RegExp(`^\\s*(\\d+)\\s+((?:同(?:\\s|　)?)|[${JP_NUM_FULL}1-9${JP_NUM_KANJI}]{2})${piecePattern}(打?)(?:\\((\\d{2})\\))?(?:\\(([^\\)]*)\\))?`);
-  // captures: n, toSquare, piece, fromXY?, timestamp?
-  let lastMove: Move|undefined;
+  const variationRe = /^変化：(\d+)手/;
 
   for (const raw of lines) {
     const line = raw.trimEnd();
-    if (!line) continue;
-    if (line.startsWith('#') || line.startsWith('----')) continue;
-    if (line.includes('：')) {
-      const [k,v] = line.split('：');
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('#') || trimmed.startsWith('----')) continue;
+
+    const variationMatch = trimmed.match(variationRe);
+    if (variationMatch) {
+      const start = parseInt(variationMatch[1], 10);
+      const targetNumber = start - 1;
+      let anchorContext: ParseContext | undefined;
+      let anchorMove: ParsedMove | undefined;
+      if (start === 1) {
+        anchorContext = rootContext;
+      } else {
+        for (let i = contextStack.length - 1; i >= 0; i--) {
+          const ctx = contextStack[i];
+          const mv = ctx.line.moves.find(m => m.n === targetNumber);
+          if (mv) {
+            anchorContext = ctx;
+            anchorMove = mv;
+            break;
+          }
+        }
+      }
+      if (!anchorContext) {
+        anchorContext = rootContext;
+        anchorMove = undefined;
+      }
+      while (contextStack.length && contextStack[contextStack.length - 1] !== anchorContext) {
+        contextStack.pop();
+      }
+      const anchorMoveCount = anchorMove ? (anchorContext.line.moves.indexOf(anchorMove) + 1) : 0;
+      const variationLine: VariationLine = {
+        startMoveNumber: start,
+        moves: [],
+        parent: { line: anchorContext.line, anchorMoveCount },
+        leadVariations: [],
+      };
+      if (anchorMove) {
+        anchorMove.variations.push(variationLine);
+      } else {
+        anchorContext.line.leadVariations.push(variationLine);
+      }
+      contextStack.push({ line: variationLine, prevMove: anchorMove });
+      continue;
+    }
+
+    if (trimmed.includes('：')) {
+      const [k, v] = trimmed.split('：');
       if (k && v) header[k.trim()] = v.trim();
       continue;
     }
-    if (line.startsWith('*')) {
-      if (lastMove) lastMove.comment = (lastMove.comment? lastMove.comment+'\n': '') + line.slice(1).trim();
+
+    if (trimmed.startsWith('*')) {
+      const ctx = contextStack[contextStack.length - 1];
+      if (ctx.prevMove) {
+        ctx.prevMove.comment = (ctx.prevMove.comment ? ctx.prevMove.comment + '\n' : '') + trimmed.slice(1).trim();
+      }
       continue;
     }
+
     const m = line.match(moveRe);
     if (m) {
-      const n = parseInt(m[1],10);
+      const ctx = contextStack[contextStack.length - 1];
+      const n = parseInt(m[1], 10);
       const toToken = m[2].replace(/[\s　]/g, '');
-      let to: {f:number;r:number}|undefined;
+      let to: { f: number; r: number } | undefined;
       if (toToken === '同') {
-        if (lastMove?.to) {
-          to = { ...lastMove.to };
+        if (ctx.prevMove?.to) {
+          to = { ...ctx.prevMove.to };
         }
       } else {
-        to = parseSquare(toToken);
+        try {
+          to = parseSquare(toToken);
+        } catch {
+          to = undefined;
+        }
       }
       if (!to) continue;
       const kind = m[3] as PieceKind;
       const drop = m[4] === '打';
-      let from: {f:number;r:number}|undefined;
+      let from: { f: number; r: number } | undefined;
       if (m[5]) {
-        const f = parseInt(m[5][0],10);
-        const r = parseInt(m[5][1],10);
+        const f = parseInt(m[5][0], 10);
+        const r = parseInt(m[5][1], 10);
         from = { f, r };
       }
       const timestamp = m[6]?.trim();
-      const mv: Move = { n, to, from, kind, drop, timestamp };
-      moves.push(mv);
-      lastMove = mv;
+      const mv: ParsedMove = {
+        n,
+        to,
+        from,
+        kind,
+        drop,
+        timestamp,
+        rawTo: toToken || undefined,
+        variations: [],
+      };
+      ctx.line.moves.push(mv);
+      ctx.prevMove = mv;
     }
   }
-  return { header, moves };
+  return { header, root };
 }
 
 function squareToDisplayIndex(f:number,r:number): { row:number; col:number } {
@@ -135,6 +213,25 @@ function squareToDisplayIndex(f:number,r:number): { row:number; col:number } {
   return { row, col };
 }
 
+function numToFullWidth(n: number): string {
+  if (n >= 1 && n <= 9) {
+    return JP_NUM_FULL[n - 1];
+  }
+  return n.toString();
+}
+
+function squareToText(square: { f: number; r: number }): string {
+  return `${numToFullWidth(square.f)}${numToFullWidth(square.r)}`;
+}
+
+function formatMoveLabel(mv: Move): string {
+  const squareText = mv.rawTo === '同' ? '同' : squareToText(mv.to);
+  const kindText = mv.kind ?? '';
+  const dropText = mv.drop ? '打' : '';
+  const fromText = !mv.drop && mv.from ? `(${mv.from.f}${mv.from.r})` : '';
+  return `${squareText}${kindText}${dropText}${fromText}`;
+}
+
 export default class ShogiKifViewer extends Plugin {
   async onload() {
     this.registerMarkdownCodeBlockProcessor('kif', (src, el, ctx) => this.renderKif(src, el, ctx));
@@ -142,53 +239,81 @@ export default class ShogiKifViewer extends Plugin {
 
   renderKif(src: string, el: HTMLElement, _ctx: MarkdownPostProcessorContext) {
     const container = el.createDiv({ cls: 'shogi-kif' });
-    const { header, moves } = parseKif(src);
+    const { header, root } = parseKif(src);
 
     let board = initialBoard();
     let hands: Hands = { B: [], W: [] };
-    let moveIdx = 0; // 0 = initial, 1..N = after that move
-    let lastFrom: {f:number;r:number}|undefined;
-    let lastTo: {f:number;r:number}|undefined;
+    let lastFrom: { f: number; r: number } | undefined;
+    let lastTo: { f: number; r: number } | undefined;
+    let latestMove: ParsedMove | undefined;
+
+    let currentLine: VariationLine = root;
+    let currentMoveIdx = 0;
+    const lineState = new WeakMap<VariationLine, number>();
 
     const toolbar = container.createDiv({ cls: 'toolbar' });
     const btnFirst = toolbar.createEl('button', { text: '⏮ 最初' });
-    const btnPrev  = toolbar.createEl('button', { text: '◀ 一手戻る' });
-    const btnNext  = toolbar.createEl('button', { text: '一手進む ▶' });
-    const btnLast  = toolbar.createEl('button', { text: '最後 ⏭' });
+    const btnPrev = toolbar.createEl('button', { text: '◀ 一手戻る' });
+    const btnNext = toolbar.createEl('button', { text: '一手進む ▶' });
+    const btnLast = toolbar.createEl('button', { text: '最後 ⏭' });
+
+    const variationBar = container.createDiv({ cls: 'variation-bar' });
+    const pathLabel = variationBar.createSpan({ cls: 'variation-current' });
+    const btnParent = variationBar.createEl('button', { text: '↩ 親の手順へ' });
+    btnParent.addClass('variation-parent');
+    const variationSelect = variationBar.createEl('select');
+    variationSelect.addClass('variation-select');
+    let availableVariations: VariationLine[] = [];
 
     const handOpponent = container.createDiv({ cls: 'hands hands-opponent' });
     const boardHost = container.createDiv({ cls: 'board' });
     const handPlayer = container.createDiv({ cls: 'hands hands-player' });
     const handDisplays: Record<Side, HTMLElement> = { W: handOpponent, B: handPlayer };
     const meta = container.createDiv({ cls: 'meta' });
+    const commentsDiv = container.createDiv({ cls: 'meta' });
 
-    function renderBoard(){
+    function lineLabel(line: VariationLine): string {
+      if (!line.parent) return '本筋';
+      const first = line.moves[0];
+      const moveText = first ? formatMoveLabel(first) : '';
+      return moveText ? `変化 ${line.startMoveNumber}手: ${moveText}` : `変化 ${line.startMoveNumber}手`;
+    }
+
+    function gatherMoves(line: VariationLine, upto: number): ParsedMove[] {
+      const count = Math.max(0, Math.min(upto, line.moves.length));
+      const prefix = line.moves.slice(0, count);
+      if (!line.parent) {
+        return prefix;
+      }
+      const parentCount = Math.max(
+        0,
+        Math.min(line.parent.anchorMoveCount, line.parent.line.moves.length)
+      );
+      const parentSeq = gatherMoves(line.parent.line, parentCount);
+      return parentSeq.concat(prefix);
+    }
+
+    function renderBoard() {
       boardHost.empty();
-      for (let r=1; r<=9; r++) {
-        for (let f=9; f>=1; f--) {
+      for (let r = 1; r <= 9; r++) {
+        for (let f = 9; f >= 1; f--) {
           const cell = boardHost.createDiv({ cls: 'cell' });
-          const P = board[r-1][f-1];
-          if (P) {
-            const pieceEl = cell.createSpan({ cls: 'piece', text: P.kind });
-            if (P.side === 'W') {
+          const piece = board[r - 1][f - 1];
+          if (piece) {
+            const pieceEl = cell.createSpan({ cls: 'piece', text: piece.kind });
+            if (piece.side === 'W') {
               pieceEl.addClass('piece-opponent');
             } else {
               pieceEl.addClass('piece-player');
             }
           }
-          if (lastTo && lastTo.f===f && lastTo.r===r) cell.addClass('highlight-to');
-          if (lastFrom && lastFrom.f===f && lastFrom.r===r) cell.addClass('highlight-from');
+          if (lastTo && lastTo.f === f && lastTo.r === r) cell.addClass('highlight-to');
+          if (lastFrom && lastFrom.f === f && lastFrom.r === r) cell.addClass('highlight-from');
         }
       }
-      const info = [
-        header['棋戦']?`棋戦: ${header['棋戦']}`:undefined,
-        header['戦型']?`戦型: ${header['戦型']}`:undefined,
-        moveIdx>0 && moves[moveIdx-1]?.timestamp?`消費時間: ${moves[moveIdx-1].timestamp}`:undefined
-      ].filter(Boolean).join(' / ');
-      meta.setText(info);
     }
 
-    function renderHands(){
+    function renderHands() {
       const sides: Side[] = ['W', 'B'];
       for (const side of sides) {
         const div = handDisplays[side];
@@ -216,78 +341,168 @@ export default class ShogiKifViewer extends Plugin {
       }
     }
 
-    function applyUpTo(idx:number){
+    function updateMeta() {
+      const info = [
+        header['棋戦'] ? `棋戦: ${header['棋戦']}` : undefined,
+        header['戦型'] ? `戦型: ${header['戦型']}` : undefined,
+        latestMove?.timestamp ? `消費時間: ${latestMove.timestamp}` : undefined,
+      ]
+        .filter(Boolean)
+        .join(' / ');
+      meta.setText(info);
+    }
+
+    function updateComments() {
+      commentsDiv.empty();
+      if (latestMove?.comment) {
+        const pre = commentsDiv.createEl('pre');
+        pre.textContent = latestMove.comment;
+      }
+    }
+
+    function applyCurrent(idx: number) {
+      const clamped = Math.max(0, Math.min(idx, currentLine.moves.length));
+      currentMoveIdx = clamped;
+      lineState.set(currentLine, currentMoveIdx);
       board = initialBoard();
       hands = { B: [], W: [] };
-      lastFrom = lastTo = undefined;
-      // Very naive move applier: uses explicit (from) if present, handles simple captures and drops, still ignores promotions
-      for (let i=0; i<idx; i++) {
-        const mv = moves[i];
-        if (!mv) break;
-        const from = mv.from;
-        const to = mv.to;
-        if (!to) continue;
-        const side: Side = (i % 2 === 0) ? 'B' : 'W';
+      lastFrom = undefined;
+      lastTo = undefined;
+      latestMove = undefined;
+      const sequence = gatherMoves(currentLine, currentMoveIdx);
+      for (const mv of sequence) {
+        const side: Side = mv.n % 2 === 1 ? 'B' : 'W';
         let moving: Piece | null = null;
         if (mv.drop) {
           const dropKind = demoteKind(mv.kind ?? '歩');
           const hand = hands[side];
           const idxInHand = hand.findIndex(k => k === dropKind);
-          if (idxInHand >= 0) hand.splice(idxInHand, 1);
+          if (idxInHand >= 0) {
+            hand.splice(idxInHand, 1);
+          }
           moving = { side, kind: dropKind };
           lastFrom = undefined;
-        } else if (from) {
-          const src = board[from.r-1][from.f-1];
+        } else if (mv.from) {
+          const src = board[mv.from.r - 1][mv.from.f - 1];
           if (!src) continue;
           moving = { ...src };
-          board[from.r-1][from.f-1] = null;
-          lastFrom = from;
+          board[mv.from.r - 1][mv.from.f - 1] = null;
+          lastFrom = mv.from;
         } else {
           continue;
         }
-
-        const target = board[to.r-1][to.f-1];
+        const to = mv.to;
+        const target = board[to.r - 1][to.f - 1];
         if (target && target.side !== side) {
           const capturedKind = demoteKind(target.kind);
           hands[side].push(capturedKind);
         }
         if (moving) {
-          board[to.r-1][to.f-1] = moving;
+          board[to.r - 1][to.f - 1] = moving;
         }
         lastTo = to;
+        latestMove = mv;
       }
-      moveIdx = idx;
       renderBoard();
       renderHands();
+      updateMeta();
+      updateComments();
     }
 
-    btnFirst.onclick = ()=> applyUpTo(0);
-    btnPrev.onclick  = ()=> applyUpTo(Math.max(0, moveIdx-1));
-    btnNext.onclick  = ()=> applyUpTo(Math.min(moves.length, moveIdx+1));
-    btnLast.onclick  = ()=> applyUpTo(moves.length);
-
-    // initial render
-    applyUpTo(0);
-
-    // If there are inline comments (*) after a move, show them beneath
-    const commentsDiv = container.createDiv({ cls: 'meta' });
-    const updateComments = () => {
-      commentsDiv.empty();
-      if (moveIdx>0) {
-        const mv = moves[moveIdx-1];
-        if (mv?.comment) {
-          const pre = commentsDiv.createEl('pre');
-          pre.textContent = mv.comment;
+    function updateVariationUI() {
+      const pathParts: string[] = [];
+      let node: VariationLine | undefined = currentLine;
+      while (node) {
+        pathParts.push(lineLabel(node));
+        node = node.parent?.line;
+      }
+      pathLabel.setText(`現在: ${pathParts.reverse().join(' → ')}`);
+      const parentInfo = currentLine.parent;
+      btnParent.disabled = !parentInfo;
+      btnParent.toggleClass('is-hidden', !parentInfo);
+      variationSelect.empty();
+      availableVariations = [];
+      const variations: VariationLine[] = [];
+      variations.push(...currentLine.leadVariations);
+      for (const mv of currentLine.moves) {
+        variations.push(...mv.variations);
+      }
+      if (!variations.length) {
+        variationSelect.addClass('is-hidden');
+        variationSelect.value = '';
+        return;
+      }
+      variationSelect.removeClass('is-hidden');
+      variationSelect.createEl('option', { text: '変化を選択', value: '' });
+      variations.forEach((variation, idx) => {
+        availableVariations.push(variation);
+        let label = lineLabel(variation);
+        const anchorCount = variation.parent?.anchorMoveCount ?? 0;
+        if (variation.parent?.line === currentLine && anchorCount > currentMoveIdx) {
+          label += '（未到達）';
         }
+        variationSelect.createEl('option', { text: label, value: String(idx) });
+      });
+      variationSelect.value = '';
+    }
+
+    function switchToVariation(variation: VariationLine) {
+      lineState.set(currentLine, currentMoveIdx);
+      currentLine = variation;
+      const saved = lineState.get(currentLine);
+      const target =
+        saved !== undefined
+          ? Math.max(0, Math.min(saved, currentLine.moves.length))
+          : 0;
+      applyCurrent(target);
+      updateVariationUI();
+    }
+
+    function goToParent() {
+      const parentInfo = currentLine.parent;
+      if (!parentInfo) return;
+      lineState.set(currentLine, currentMoveIdx);
+      currentLine = parentInfo.line;
+      const saved = lineState.get(currentLine);
+      const target =
+        saved !== undefined
+          ? Math.max(0, Math.min(saved, currentLine.moves.length))
+          : Math.min(parentInfo.anchorMoveCount, currentLine.moves.length);
+      applyCurrent(target);
+      updateVariationUI();
+    }
+
+    btnFirst.onclick = () => {
+      applyCurrent(0);
+      updateVariationUI();
+    };
+    btnPrev.onclick = () => {
+      applyCurrent(Math.max(0, currentMoveIdx - 1));
+      updateVariationUI();
+    };
+    btnNext.onclick = () => {
+      applyCurrent(Math.min(currentLine.moves.length, currentMoveIdx + 1));
+      updateVariationUI();
+    };
+    btnLast.onclick = () => {
+      applyCurrent(currentLine.moves.length);
+      updateVariationUI();
+    };
+    btnParent.onclick = () => {
+      goToParent();
+    };
+    variationSelect.onchange = () => {
+      const value = variationSelect.value;
+      if (!value) return;
+      const idx = parseInt(value, 10);
+      if (Number.isNaN(idx)) return;
+      const variation = availableVariations[idx];
+      if (variation) {
+        switchToVariation(variation);
       }
     };
 
-    // patch buttons to also refresh comments
-    const wrap = (fn: ()=>void) => () => { fn(); updateComments(); };
-    btnFirst.onclick = wrap(()=>applyUpTo(0));
-    btnPrev.onclick  = wrap(()=>applyUpTo(Math.max(0, moveIdx-1)));
-    btnNext.onclick  = wrap(()=>applyUpTo(Math.min(moves.length, moveIdx+1)));
-    btnLast.onclick  = wrap(()=>applyUpTo(moves.length));
-    updateComments();
+    applyCurrent(0);
+    updateVariationUI();
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,26 @@ display: flex;
 gap: 6px;
 margin-bottom: 8px;
 }
+.shogi-kif .variation-bar {
+display: flex;
+flex-wrap: wrap;
+align-items: center;
+gap: 6px;
+margin-bottom: 8px;
+font-size: 0.9em;
+}
+.shogi-kif .variation-current {
+font-weight: 600;
+}
+.shogi-kif .variation-select {
+min-width: 180px;
+}
+.shogi-kif .variation-parent:disabled {
+opacity: 0.5;
+}
+.shogi-kif .is-hidden {
+display: none !important;
+}
 .shogi-kif .hands {
 display: flex;
 justify-content: center;


### PR DESCRIPTION
## Summary
- parse KIF records into a tree of main line and variations so branch moves can be replayed
- add UI controls to switch to available variations and return to parent positions while keeping comments and timestamps
- style the new variation toolbar elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf2f39b14c832f93512fbe47919f3d