### PR TITLE
Update move list layout with prefixed symbols

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -376,40 +376,16 @@ export default class ShogiKifViewer extends Plugin {
       const executedMoves = new Set(gatherMoves(currentLine, currentMoveIdx));
       const table = moveListBody.createEl('table', { cls: 'move-table' });
       const tbody = table.createEl('tbody');
-      const grouped = new Map<number, { n: number; B?: ParsedMove; W?: ParsedMove }>();
       for (const mv of displaySequence) {
-        const num = mv.n;
-        let entry = grouped.get(num);
-        if (!entry) {
-          entry = { n: num };
-          grouped.set(num, entry);
-        }
-        if (mv.n % 2 === 1) {
-          entry.B = mv;
-        } else {
-          entry.W = mv;
-        }
-      }
-      const ordered = Array.from(grouped.values()).sort((a, b) => a.n - b.n);
-      for (const entry of ordered) {
         const row = tbody.createEl('tr');
-        row.createEl('th', { text: entry.n.toString() });
-        const senteCell = row.createEl('td');
-        const goteCell = row.createEl('td');
-        if (entry.B) {
-          senteCell.setText(formatMoveLabel(entry.B));
-          if (executedMoves.has(entry.B)) senteCell.addClass('move-done');
-          if (latestMove && latestMove === entry.B) senteCell.addClass('move-current');
-        } else {
-          senteCell.addClass('move-empty');
-        }
-        if (entry.W) {
-          goteCell.setText(formatMoveLabel(entry.W));
-          if (executedMoves.has(entry.W)) goteCell.addClass('move-done');
-          if (latestMove && latestMove === entry.W) goteCell.addClass('move-current');
-        } else {
-          goteCell.addClass('move-empty');
-        }
+        row.createEl('th', { text: mv.n.toString() });
+        const cell = row.createEl('td');
+        const prefix = mv.n % 2 === 1 ? '▲' : '△';
+        const prefixCls = mv.n % 2 === 1 ? 'move-prefix-sente' : 'move-prefix-gote';
+        cell.createSpan({ cls: ['move-prefix', prefixCls], text: prefix });
+        cell.createSpan({ cls: 'move-text', text: formatMoveLabel(mv) });
+        if (executedMoves.has(mv)) cell.addClass('move-done');
+        if (latestMove && latestMove === mv) cell.addClass('move-current');
       }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -66,22 +66,41 @@ font-weight: 600;
 color: var(--text-muted);
 }
 .shogi-kif .move-table td {
-font-variant-numeric: tabular-nums;
+  font-variant-numeric: tabular-nums;
+}
+.shogi-kif .move-table .move-prefix {
+  display: inline-block;
+  width: 1.4em;
+  margin-right: 6px;
+  font-weight: 600;
+  text-align: center;
+}
+.shogi-kif .move-table .move-text {
+  display: inline-block;
+}
+.shogi-kif .move-table .move-prefix-sente {
+  color: #d9480f;
+}
+.shogi-kif .move-table .move-prefix-gote {
+  color: #1d6fda;
 }
 .shogi-kif .move-table tr:last-child th,
 .shogi-kif .move-table tr:last-child td {
-border-bottom: none;
+  border-bottom: none;
 }
 .shogi-kif .move-table td.move-empty {
-color: var(--text-faint);
+  color: var(--text-faint);
 }
 .shogi-kif .move-table td.move-done {
-color: var(--text-normal);
+  color: var(--text-normal);
 }
 .shogi-kif .move-table td.move-current {
-background: var(--interactive-accent);
-color: var(--text-on-accent, var(--background-primary));
-border-radius: 4px;
+  background: var(--interactive-accent);
+  color: var(--text-on-accent, var(--background-primary));
+  border-radius: 4px;
+}
+.shogi-kif .move-table td.move-current .move-prefix {
+  color: inherit;
 }
 .shogi-kif .variation-current {
 font-weight: 600;


### PR DESCRIPTION
## Summary
- render the move list as a single column and prefix each move with a ▲/△ marker that matches the side to move
- style the move list prefixes with contrasting colors while keeping the current-move highlight legible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf3c799f5c832f9464991e2182d5af