### PR TITLE
Adjust hand piece layout

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -267,9 +267,10 @@ export default class ShogiKifViewer extends Plugin {
 
     const layout = container.createDiv({ cls: 'board-layout' });
     const boardArea = layout.createDiv({ cls: 'board-area' });
-    const handOpponent = boardArea.createDiv({ cls: 'hands hands-opponent' });
-    const boardHost = boardArea.createDiv({ cls: 'board' });
-    const handPlayer = boardArea.createDiv({ cls: 'hands hands-player' });
+    const boardWrapper = boardArea.createDiv({ cls: 'board-wrapper' });
+    const handOpponent = boardWrapper.createDiv({ cls: 'hands hands-opponent' });
+    const boardHost = boardWrapper.createDiv({ cls: 'board' });
+    const handPlayer = boardWrapper.createDiv({ cls: 'hands hands-player' });
     const handDisplays: Record<Side, HTMLElement> = { W: handOpponent, B: handPlayer };
     const meta = boardArea.createDiv({ cls: 'meta' });
     const commentsDiv = boardArea.createDiv({ cls: 'meta comments' });
@@ -324,11 +325,10 @@ export default class ShogiKifViewer extends Plugin {
       for (const side of sides) {
         const div = handDisplays[side];
         div.empty();
-        const label = side === 'B' ? '先手' : '後手';
-        div.createSpan({ cls: 'hands-label', text: `${label}持ち駒: ` });
         const pieces = hands[side];
         if (!pieces.length) {
-          div.createSpan({ cls: 'hands-empty', text: 'なし' });
+          const empty = div.createSpan({ cls: 'hands-empty', text: 'なし' });
+          if (side === 'W') empty.addClass('hand-piece-opponent');
           continue;
         }
         const counts = new Map<PieceKind, number>();
@@ -338,11 +338,19 @@ export default class ShogiKifViewer extends Plugin {
         for (const kind of HAND_PIECE_ORDER) {
           const cnt = counts.get(kind);
           if (!cnt) continue;
-          div.createSpan({ cls: 'hand-piece', text: cnt > 1 ? `${kind}${cnt}` : kind });
+          const span = div.createSpan({
+            cls: 'hand-piece',
+            text: cnt > 1 ? `${kind}${cnt}` : kind,
+          });
+          if (side === 'W') span.addClass('hand-piece-opponent');
           counts.delete(kind);
         }
         for (const [kind, cnt] of counts) {
-          div.createSpan({ cls: 'hand-piece', text: cnt > 1 ? `${kind}${cnt}` : kind });
+          const span = div.createSpan({
+            cls: 'hand-piece',
+            text: cnt > 1 ? `${kind}${cnt}` : kind,
+          });
+          if (side === 'W') span.addClass('hand-piece-opponent');
         }
       }
     }

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,21 @@ flex-direction: column;
 align-items: center;
 gap: 6px;
 }
+
+.shogi-kif .board-wrapper {
+display: grid;
+grid-template-areas:
+  'gote'
+  'board'
+  'sente';
+justify-items: stretch;
+gap: 6px;
+}
+
+.shogi-kif .board-wrapper .board {
+grid-area: board;
+justify-self: center;
+}
 .shogi-kif .move-list {
 flex: 1 1 220px;
 min-width: 220px;
@@ -97,22 +112,35 @@ display: none !important;
 }
 .shogi-kif .hands {
 display: flex;
-justify-content: center;
-align-items: center;
-gap: 6px;
-margin: 4px 0;
-flex-wrap: wrap;
+flex-direction: column;
+gap: 4px;
+margin: 0;
 font-size: 0.9em;
 }
-.shogi-kif .hands-label {
-font-weight: 600;
+.shogi-kif .hands-opponent {
+grid-area: gote;
+justify-self: start;
+align-items: flex-start;
+align-self: start;
+}
+.shogi-kif .hands-player {
+grid-area: sente;
+justify-self: end;
+align-items: flex-end;
+align-self: end;
+text-align: right;
+}
+.shogi-kif .hand-piece-opponent {
+transform: rotate(180deg);
 }
 .shogi-kif .hand-piece {
+display: inline-block;
 padding: 2px 6px;
 border-radius: 4px;
 background: var(--background-secondary);
 }
 .shogi-kif .hands-empty {
+display: inline-block;
 opacity: 0.6;
 }
 .shogi-kif .board {


### PR DESCRIPTION
## Summary
- move the captured-piece containers into a dedicated board wrapper so each side can be positioned independently
- update the hand rendering logic to drop the textual labels and rotate the opponent pieces while keeping counts
- restyle the hand containers to stack vertically at the board's top-left and bottom-right corners

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf3cdc64f4832fb9b2426f642887fc