### PR TITLE
Enable jumping to moves from the move list

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -481,6 +481,14 @@ export default class ShogiKifViewer extends Plugin {
       }
     }
 
+    function jumpTo(line: VariationLine, moveIndex: number) {
+      lineState.set(currentLine, currentMoveIdx);
+      currentLine = line;
+      const targetCount = Math.max(0, Math.min(moveIndex + 1, currentLine.moves.length));
+      applyCurrent(targetCount);
+      updateVariationUI();
+    }
+
     function hasAnyMoves(line: VariationLine): boolean {
       if (line.moves.length > 0) {
         return true;
@@ -561,7 +569,7 @@ export default class ShogiKifViewer extends Plugin {
           renderVariationLine(lead, childrenEl, indentLevel + 1);
         }
 
-        for (const mv of line.moves) {
+        line.moves.forEach((mv, moveIndex) => {
           const moveGroup = childrenEl.createDiv({ cls: 'variation-move-group' });
           const moveRow = moveGroup.createDiv({ cls: 'variation-move' });
           if (executedMoves.has(mv)) {
@@ -570,6 +578,9 @@ export default class ShogiKifViewer extends Plugin {
           if (latestMove && latestMove === mv) {
             moveRow.addClass('is-current');
           }
+          moveRow.onclick = () => {
+            jumpTo(line, moveIndex);
+          };
           moveRow.createSpan({ cls: 'move-number', text: mv.n.toString() });
           const prefix = mv.n % 2 === 1 ? '▲' : '△';
           const prefixCls = mv.n % 2 === 1 ? 'move-prefix-sente' : 'move-prefix-gote';
@@ -614,7 +625,7 @@ export default class ShogiKifViewer extends Plugin {
           } else {
             moveRow.createSpan({ cls: 'variation-branch-placeholder' });
           }
-        }
+        });
       };
 
       renderVariationLine(root, tree, 0);

--- a/styles.css
+++ b/styles.css
@@ -160,6 +160,7 @@ padding: 4px;
 border-radius: 4px;
 font-variant-numeric: tabular-nums;
 color: var(--text-muted);
+cursor: pointer;
 }
 .shogi-kif .variation-move.has-branch .variation-branch-toggle {
 visibility: visible;


### PR DESCRIPTION
## Summary
- add navigation logic so clicking a move in the tree jumps to that position
- show a pointer cursor to indicate move rows are clickable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfc3967860832f81960dfcbea1da8f