### PR TITLE
Update author metadata to Luis8492

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 "name": "Shogi KIF Viewer",
 "version": "0.1.0",
 "minAppVersion": "1.5.0",
-"author": "You",
+"author": "Luis8492",
 "description": "Render interactive shogi boards from KIF code blocks in notes.",
 "isDesktopOnly": false
 }


### PR DESCRIPTION
## Summary
- update the plugin manifest author field to the publisher name Luis8492
- verify no other documentation references required changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d94b5cbd90832fa729197c6a4fba44