### PR TITLE
Place KIF comments below board to stabilize layout

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -488,7 +488,6 @@ export default class ShogiKifViewer extends Plugin {
     const handPlayer = boardWrapper.createDiv({ cls: 'hands hands-player' });
     const handDisplays: Record<Side, HTMLElement> = { W: handOpponent, B: handPlayer };
     const meta = boardArea.createDiv({ cls: 'meta' });
-    const commentsDiv = boardArea.createDiv({ cls: 'meta comments' });
 
     const splitter = layout.createDiv({ cls: 'board-move-splitter' });
     splitter.setAttr('role', 'separator');
@@ -500,6 +499,9 @@ export default class ShogiKifViewer extends Plugin {
     const moveListContainer = layout.createDiv({ cls: 'move-list' });
     moveListContainer.createDiv({ cls: 'move-list-title', text: '棋譜' });
     const moveListBody = moveListContainer.createDiv({ cls: 'move-list-body' });
+
+    const commentsContainer = container.createDiv({ cls: 'comments-container' });
+    const commentsDiv = commentsContainer.createDiv({ cls: 'meta comments' });
 
     const MIN_MOVE_LIST_HEIGHT = 160;
     let isStackedLayout = false;

--- a/styles.css
+++ b/styles.css
@@ -389,3 +389,12 @@ white-space: pre-wrap;
 .shogi-kif .board-area .meta {
 align-self: stretch;
 }
+
+.shogi-kif .comments-container {
+  margin-top: 8px;
+}
+
+.shogi-kif .comments-container .meta {
+  align-self: stretch;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- move the comments container outside of the board area so it renders below the board and move list
- add styling for the new comments container to keep full-width alignment without affecting the board layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e0857b45d0832f94ebcac01d64ddce