### PR TITLE
Auto-scroll move list to keep current move visible

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -934,6 +934,23 @@ export default class ShogiKifViewer extends Plugin {
       };
 
       renderVariationLine(root, tree, 0);
+      const currentMoveEl = moveListBody.querySelector('.variation-move.is-current') as
+        | HTMLElement
+        | null;
+      if (currentMoveEl) {
+        const bodyRect = moveListBody.getBoundingClientRect();
+        const moveRect = currentMoveEl.getBoundingClientRect();
+        if (moveRect.top < bodyRect.top || moveRect.bottom > bodyRect.bottom) {
+          const behavior = isPlaying ? 'smooth' : 'auto';
+          currentMoveEl.scrollIntoView({
+            block: 'nearest',
+            inline: 'nearest',
+            behavior,
+          });
+        }
+      } else if (currentMoveIdx === 0) {
+        moveListBody.scrollTop = 0;
+      }
       requestStackedStateUpdate();
     }
 


### PR DESCRIPTION
## Summary
- automatically scroll the move list to keep the current move in view, using smooth scrolling while autoplay is active
- reset the move list position when returning to the initial position with no highlighted move

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e087177770832f8411322588272499