### PR TITLE
Ensure move list height matches board across layouts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -71,31 +71,9 @@ display: none;
 }
 
 .shogi-kif .board-layout.is-stacked .board-move-splitter {
-display: flex;
-align-items: center;
-justify-content: center;
-height: 10px;
-cursor: row-resize;
-background: var(--background-modifier-border);
-border-radius: 4px;
-position: relative;
-}
-
-.shogi-kif .board-layout.is-stacked .board-move-splitter:focus-visible {
-outline: 2px solid var(--interactive-accent);
-outline-offset: 2px;
-}
-
-.shogi-kif .board-layout.is-stacked .board-move-splitter::after {
-content: '';
-width: 36px;
-height: 2px;
-background: var(--text-muted);
-border-radius: 1px;
-}
-
-.shogi-kif .board-layout.is-stacked .board-move-splitter.is-dragging {
-background: var(--interactive-accent);
+  display: block;
+  height: 16px;
+  pointer-events: none;
 }
 .shogi-kif .board-area {
 display: flex;


### PR DESCRIPTION
## Summary
- synchronize the move list height with the board area regardless of layout mode
- remove the draggable splitter logic and restyle the stacked spacer to reflect the automatic sizing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0899ddbc8832fa55f2e1b53b6021e