### PR TITLE
Swap highlight colors for move origin and destination squares

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -423,13 +423,13 @@ user-select: none;
 }
 .shogi-kif .cell.highlight-to {
   outline: none;
-  box-shadow: inset 0 0 0 2px rgba(106, 168, 79, 0.5);
-  background-color: rgba(106, 168, 79, 0.12);
+  box-shadow: inset 0 0 0 2px rgba(204, 0, 0, 0.45);
+  background-color: rgba(204, 0, 0, 0.08);
 }
 .shogi-kif .cell.highlight-from {
   outline: none;
-  box-shadow: inset 0 0 0 2px rgba(204, 0, 0, 0.45);
-  background-color: rgba(204, 0, 0, 0.08);
+  box-shadow: inset 0 0 0 2px rgba(106, 168, 79, 0.5);
+  background-color: rgba(106, 168, 79, 0.12);
 }
 .shogi-kif .meta {
 margin-top: 6px; font-size: .9em; opacity: .9;


### PR DESCRIPTION
## Summary
- swap the shogi board highlight colors so the destination square now uses the former origin styling and vice versa

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e0e676d4b0832fb4a2701819657107