### PR TITLE
chore: ensure node_modules is ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .idea
 
 # npm
-node_modules
+node_modules/
 
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.


### PR DESCRIPTION
## Summary
- remove the root-level node_modules directory from version control
- ensure the gitignore explicitly ignores the node_modules/ folder

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e21231be34832f990b9b9f7dd60c4e