### PR TITLE
Replace inline styling with theme-friendly CSS classes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -509,24 +509,6 @@ export default class ShogiKifViewer extends Plugin {
     let isStackedLayout = false;
     let stackedUpdateQueued = false;
 
-    function syncMoveListHeightToBoard() {
-      const boardHeight = Math.round(boardArea.getBoundingClientRect().height);
-      if (boardHeight > 0) {
-        moveListContainer.style.height = `${boardHeight}px`;
-      } else {
-        moveListContainer.style.removeProperty('height');
-      }
-      if (isStackedLayout) {
-        moveListContainer.style.flex = '0 0 auto';
-      } else {
-        moveListContainer.style.removeProperty('flex');
-      }
-    }
-
-    function applyMoveListSizing() {
-      syncMoveListHeightToBoard();
-    }
-
     function performStackedStateUpdate() {
       const layoutWidth = layout.clientWidth;
       const boardWidth = boardWrapper.getBoundingClientRect().width;
@@ -545,8 +527,6 @@ export default class ShogiKifViewer extends Plugin {
         splitter.setAttr('aria-orientation', 'horizontal');
         splitter.tabIndex = -1;
       }
-
-      applyMoveListSizing();
     }
 
     function requestStackedStateUpdate() {
@@ -564,7 +544,7 @@ export default class ShogiKifViewer extends Plugin {
     layoutResizeObserver.observe(layout);
     this.register(() => layoutResizeObserver.disconnect());
     const boardAreaResizeObserver = new ResizeObserver(() => {
-      syncMoveListHeightToBoard();
+      requestStackedStateUpdate();
     });
     boardAreaResizeObserver.observe(boardArea);
     this.register(() => boardAreaResizeObserver.disconnect());
@@ -827,13 +807,16 @@ export default class ShogiKifViewer extends Plugin {
 
       const tree = moveListBody.createDiv({ cls: 'variation-tree' });
 
+      const MAX_VARIATION_INDENT_CLASS_LEVEL = 20;
+
       const renderVariationLine = (
         line: VariationLine,
         parentEl: HTMLElement,
         indentLevel: number,
       ) => {
         const nodeEl = parentEl.createDiv({ cls: 'variation-node' });
-        nodeEl.style.setProperty('--indent-level', indentLevel.toString());
+        const clampedIndentLevel = Math.min(indentLevel, MAX_VARIATION_INDENT_CLASS_LEVEL);
+        nodeEl.addClass(`indent-level-${clampedIndentLevel}`);
         if (activeLines.has(line)) {
           nodeEl.addClass('is-active-line');
         }

--- a/styles.css
+++ b/styles.css
@@ -71,7 +71,10 @@ flex-wrap: nowrap;
 
 .shogi-kif .board-layout.is-stacked .board-area,
 .shogi-kif .board-layout.is-stacked .move-list {
-width: 100%;
+  width: 100%;
+}
+.shogi-kif .board-layout.is-stacked .move-list {
+  flex: 0 0 auto;
 }
 
 .shogi-kif .board-layout .board-move-splitter {
@@ -209,9 +212,31 @@ padding: 2px 0;
 }
 .shogi-kif .variation-node {
 --variation-indent-size: 18px;
-padding-left: calc(var(--variation-indent-size) * var(--indent-level, 0));
+--indent-level: 0;
+padding-left: calc(var(--variation-indent-size) * var(--indent-level));
 border-left: 2px solid transparent;
 }
+.shogi-kif .variation-node.indent-level-0 { --indent-level: 0; }
+.shogi-kif .variation-node.indent-level-1 { --indent-level: 1; }
+.shogi-kif .variation-node.indent-level-2 { --indent-level: 2; }
+.shogi-kif .variation-node.indent-level-3 { --indent-level: 3; }
+.shogi-kif .variation-node.indent-level-4 { --indent-level: 4; }
+.shogi-kif .variation-node.indent-level-5 { --indent-level: 5; }
+.shogi-kif .variation-node.indent-level-6 { --indent-level: 6; }
+.shogi-kif .variation-node.indent-level-7 { --indent-level: 7; }
+.shogi-kif .variation-node.indent-level-8 { --indent-level: 8; }
+.shogi-kif .variation-node.indent-level-9 { --indent-level: 9; }
+.shogi-kif .variation-node.indent-level-10 { --indent-level: 10; }
+.shogi-kif .variation-node.indent-level-11 { --indent-level: 11; }
+.shogi-kif .variation-node.indent-level-12 { --indent-level: 12; }
+.shogi-kif .variation-node.indent-level-13 { --indent-level: 13; }
+.shogi-kif .variation-node.indent-level-14 { --indent-level: 14; }
+.shogi-kif .variation-node.indent-level-15 { --indent-level: 15; }
+.shogi-kif .variation-node.indent-level-16 { --indent-level: 16; }
+.shogi-kif .variation-node.indent-level-17 { --indent-level: 17; }
+.shogi-kif .variation-node.indent-level-18 { --indent-level: 18; }
+.shogi-kif .variation-node.indent-level-19 { --indent-level: 19; }
+.shogi-kif .variation-node.indent-level-20 { --indent-level: 20; }
 .shogi-kif .variation-node.is-active-line {
 border-left-color: var(--interactive-accent);
 }


### PR DESCRIPTION
## Summary
- remove the runtime height/flex adjustments for the move list and rely on layout resize observers instead
- map variation tree indentation levels to CSS classes so styling lives in `styles.css`
- extend the stylesheet with stacked layout flex handling and class-based indent offsets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e35e0dbf00832fa64c9a715b5e715f