### PR TITLE
Fix BOD parser to read 先手の持駒 placed after board rows

### DIFF
--- a/src/kif-viewer.ts
+++ b/src/kif-viewer.ts
@@ -531,7 +531,7 @@ function parseBodSource(text: string): ParsedSource {
       header['手番'] = trimmed;
       continue;
     }
-    if (!trimmed.includes('|')) continue;
+    if (!trimmed.includes('|') || boardRank > BOARD_SIZE) continue;
     const cells = line.match(/\|([^|]+)\|/);
     if (!cells) continue;
     const tokens = parseBodRowTokens(cells[1]);
@@ -546,7 +546,6 @@ function parseBodSource(text: string): ParsedSource {
       board[boardRank - 1][BOARD_SIZE - f] = { side, kind };
     }
     boardRank += 1;
-    if (boardRank > BOARD_SIZE) break;
   }
   return {
     header,


### PR DESCRIPTION
### Motivation
- The BOD parser stopped iterating input lines after consuming the 9 board rows, so a `先手の持駒` line placed below the board was ignored and the sente hand did not appear.

### Description
- Change `parseBodSource` in `src/kif-viewer.ts` to continue scanning lines after board rows and limit board-row parsing to when `boardRank <= BOARD_SIZE` by adding the condition `if (!trimmed.includes('|') || boardRank > BOARD_SIZE) continue;` and removing the early `break`.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f99cfb698832f9baea9f91c841096)